### PR TITLE
[ORKWeightAnswerFormat] Improvements

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -496,6 +496,7 @@
 		BC13CE421B066A990044153C /* ORKStepNavigationRule_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = BC13CE411B066A990044153C /* ORKStepNavigationRule_Internal.h */; };
 		BC1C032C1CA301E300869355 /* ORKHeightPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = BC1C032A1CA301E300869355 /* ORKHeightPicker.h */; };
 		BC1C032D1CA301E300869355 /* ORKHeightPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = BC1C032B1CA301E300869355 /* ORKHeightPicker.m */; };
+		BC2908BC1FBD628F0030AB89 /* ORKTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = BC2908BB1FBD628F0030AB89 /* ORKTypes.m */; };
 		BC4194291AE8453A00073D6B /* ORKObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = BC4194271AE8453A00073D6B /* ORKObserver.h */; };
 		BC41942A1AE8453A00073D6B /* ORKObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = BC4194281AE8453A00073D6B /* ORKObserver.m */; };
 		BC4A213F1C85FC0000BFC271 /* ORKBarGraphChartView.h in Headers */ = {isa = PBXBuildFile; fileRef = BC4A213D1C85FC0000BFC271 /* ORKBarGraphChartView.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1131,6 +1132,7 @@
 		BC13CE411B066A990044153C /* ORKStepNavigationRule_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKStepNavigationRule_Internal.h; sourceTree = "<group>"; };
 		BC1C032A1CA301E300869355 /* ORKHeightPicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKHeightPicker.h; sourceTree = "<group>"; };
 		BC1C032B1CA301E300869355 /* ORKHeightPicker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKHeightPicker.m; sourceTree = "<group>"; };
+		BC2908BB1FBD628F0030AB89 /* ORKTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKTypes.m; sourceTree = "<group>"; };
 		BC4194271AE8453A00073D6B /* ORKObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKObserver.h; sourceTree = "<group>"; };
 		BC4194281AE8453A00073D6B /* ORKObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKObserver.m; sourceTree = "<group>"; };
 		BC4A213D1C85FC0000BFC271 /* ORKBarGraphChartView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ORKBarGraphChartView.h; path = Charts/ORKBarGraphChartView.h; sourceTree = "<group>"; };
@@ -1961,6 +1963,7 @@
 		B12EFF3D1AB2121000A80147 /* Definitions */ = {
 			isa = PBXGroup;
 			children = (
+				BC2908BB1FBD628F0030AB89 /* ORKTypes.m */,
 				BCB8133B1C98367A00346561 /* ORKTypes.h */,
 				86C40B7B1A8D7C5C00081FAC /* ORKDefines.h */,
 				86C40B7D1A8D7C5C00081FAC /* ORKErrors.h */,
@@ -3099,6 +3102,7 @@
 				2433C9E41B9A506F0052D375 /* ORKKeychainWrapper.m in Sources */,
 				86C40CA61A8D7C5C00081FAC /* ORKLocationRecorder.m in Sources */,
 				86C40CB61A8D7C5C00081FAC /* ORKTouchRecorder.m in Sources */,
+				BC2908BC1FBD628F0030AB89 /* ORKTypes.m in Sources */,
 				B12EA0161B0D73A500F9F554 /* ORKToneAudiometryPracticeStep.m in Sources */,
 				CBD34A5B1BB207FC00F204EA /* ORKSurveyAnswerCellForLocation.m in Sources */,
 				959A2C011D68B9DA00841B04 /* ORKRangeOfMotionStepViewController.m in Sources */,

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -175,9 +175,9 @@ ORK_CLASS_AVAILABLE
 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                                                   numericPrecision:(ORKNumericPrecision)numericPrecision
-                                                      defaultValue:(nullable NSNumber *)defaultValue
+                                                      minimumValue:(nullable NSNumber *)minimumValue
                                                       maximumValue:(nullable NSNumber *)maximumValue
-                                                      minimumValue:(nullable NSNumber *)minimumValue;
+                                                      defaultValue:(nullable NSNumber *)defaultValue;
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat;
 
@@ -1514,20 +1514,20 @@ ORK_CLASS_AVAILABLE
                                     system. If you pass `ORKNumericPrecissionHigher`, the picker
                                     use 0.01 gr increments for the metric measurement system,
                                     and ounce increments for the USC measurement system.
- @param defaultValue            The default value to display. When the value of this parameter is
-                                    `nil`, the picker displays 60 kg (or 133 lbs).
- @param maximumValue            The maximum value that is accessible in the picker. If the value of
-                                    this parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
  @param minimumValue            The minimum value that is accessible in the picker. If the value of
                                     this parameter is `nil`, 0 kg (or 0 lbs) is the minimum.
+ @param maximumValue            The maximum value that is accessible in the picker. If the value of
+                                    this parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
+ @param defaultValue            The default value to display. When the value of this parameter is
+                                    `nil`, the picker displays 60 kg (or 133 lbs).
  
  @return An initialized weight answer format.
  */
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision
-                             defaultValue:(nullable NSNumber *)defaultValue
+                             minimumValue:(nullable NSNumber *)minimumValue
                              maximumValue:(nullable NSNumber *)maximumValue
-                             minimumValue:(nullable NSNumber *)minimumValue NS_DESIGNATED_INITIALIZER;
+                             defaultValue:(nullable NSNumber *)defaultValue NS_DESIGNATED_INITIALIZER;
 
 /**
  Indicates the measurement system used by the answer format.

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -175,9 +175,9 @@ ORK_CLASS_AVAILABLE
 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                                                   numericPrecision:(ORKNumericPrecision)numericPrecision
-                                                      minimumValue:(nullable NSNumber *)minimumValue
-                                                      maximumValue:(nullable NSNumber *)maximumValue
-                                                      defaultValue:(nullable NSNumber *)defaultValue;
+                                                      minimumValue:(double)minimumValue
+                                                      maximumValue:(double)maximumValue
+                                                      defaultValue:(double)defaultValue;
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat;
 
@@ -1514,20 +1514,27 @@ ORK_CLASS_AVAILABLE
                                     system. If you pass `ORKNumericPrecissionHigher`, the picker
                                     use 0.01 gr increments for the metric measurement system,
                                     and ounce increments for the USC measurement system.
- @param minimumValue            The minimum value that is accessible in the picker. If the value of
-                                    this parameter is `nil`, 0 kg (or 0 lbs) is the minimum.
- @param maximumValue            The maximum value that is accessible in the picker. If the value of
-                                    this parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
- @param defaultValue            The default value to display. When the value of this parameter is
-                                    `nil`, the picker displays 60 kg (or 133 lbs).
+ @param minimumValue            The minimum value that is displayed in the picker. If you specify
+                                    `ORKDefaultValue`, the minimum values are 0 kg when using the
+                                    metric measurement system and 0 lbs when using the USC
+                                    measurement system.
+ @param maximumValue            The maximum value that is displayed in the picker. If you specify
+                                    `ORKDefaultValue`, the maximum values are 657 kg when using the
+                                    metric measurement system and 1,450 lbs when using the USC
+                                    measurement system.
+ @param defaultValue            The default value to be initially selected in the picker. If you
+                                    specify `ORKDefaultValue`, the initally selected values are
+                                    60 kg when using the metric measurement system and 133 lbs when
+                                    using the USC measurement system. This value must be between
+                                    `minimumValue` and `maximumValue`.
  
  @return An initialized weight answer format.
  */
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision
-                             minimumValue:(nullable NSNumber *)minimumValue
-                             maximumValue:(nullable NSNumber *)maximumValue
-                             defaultValue:(nullable NSNumber *)defaultValue NS_DESIGNATED_INITIALIZER;
+                             minimumValue:(double)minimumValue
+                             maximumValue:(double)maximumValue
+                             defaultValue:(double)defaultValue NS_DESIGNATED_INITIALIZER;
 
 /**
  Indicates the measurement system used by the answer format.
@@ -1550,25 +1557,29 @@ ORK_CLASS_AVAILABLE
 @property (readonly, getter=isAdditionalPrecision) ORKNumericPrecision numericPrecission;
 
 /**
- The value to use as the default in the specified measurement system.
+ The minimum value that is displayed in the picker.
  
- When the value of this property is `nil`, 60 kg (or 133 lbs) is used as the default.
+ When this property has a value equal to `ORKDefaultValue`, the minimum values are 0 kg when using
+ the metric measurement system and 0 lbs when using the USC measurement system.
  */
-@property (copy, readonly, nullable) NSNumber *defaultValue;
+@property (readonly) double minimumValue;
 
 /**
- The minimum allowed value in the specified measurement system.
+ The maximum value that is displayed in the picker.
  
- When the value of this property is `nil`, 0 kg (or 0 lbs) is the minimum.
+ When this property has a value equal to `ORKDefaultValue`, the maximum values are 657 kg when using
+ the metric measurement system and 1,450 lbs when using the USC measurement system.
  */
-@property (copy, readonly, nullable) NSNumber *minimumValue;
+@property (readonly) double maximumValue;
 
 /**
- The maximum allowed value in the specified measurement system.
+ The default value to initially selected in the picker.
  
- When the value of this property is `nil`, 657 kg (or 1,450 lbs) is the maximum.
+ When this property has a value equal to `ORKDefaultValue`, the initally selected values are 60 kg
+ when using the metric measurement system and 133 lbs when using the USC measurement system. This
+ value must be between `minimumValue` and `maximumValue`.
  */
-@property (copy, readonly, nullable) NSNumber *maximumValue;
+@property (readonly) double defaultValue;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -158,20 +158,26 @@ ORK_CLASS_AVAILABLE
 + (ORKEmailAnswerFormat *)emailAnswerFormat;
 
 + (ORKTimeIntervalAnswerFormat *)timeIntervalAnswerFormat;
+
 + (ORKTimeIntervalAnswerFormat *)timeIntervalAnswerFormatWithDefaultInterval:(NSTimeInterval)defaultInterval
                                                                         step:(NSInteger)step;
 
 + (ORKHeightAnswerFormat *)heightAnswerFormat;
+
 + (ORKHeightAnswerFormat *)heightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem;
 
 + (ORKWeightAnswerFormat *)weightAnswerFormat;
+
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem;
-+ (ORKWeightAnswerFormat *)weightAnswerFormatWithDefaultValue:(nullable NSNumber *)defaultValue
-                                                 minimumValue:(nullable NSNumber *)minimumValue
-                                                 maximumValue:(nullable NSNumber *)maximumValue
-                                                valueInterval:(nullable NSNumber *)valueInterval
-                                          additionalPrecision:(BOOL)additionalPrecision
-                                            measurementSystem:(ORKMeasurementSystem)measurementSystem;
+
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                                                  numericPrecision:(ORKNumericPrecision)numericPrecision;
+
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                                                  numericPrecision:(ORKNumericPrecision)numericPrecision
+                                                      defaultValue:(nullable NSNumber *)defaultValue
+                                                      maximumValue:(nullable NSNumber *)maximumValue
+                                                      minimumValue:(nullable NSNumber *)minimumValue;
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat;
 
@@ -1433,7 +1439,7 @@ ORK_CLASS_AVAILABLE
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
 
 /**
- Indicates the measurement system used by the answer format.
+ The measurement system used by the answer format.
  */
 @property (readonly) ORKMeasurementSystem measurementSystem;
 
@@ -1468,37 +1474,80 @@ ORK_CLASS_AVAILABLE
  
  @return An initialized weight answer format.
  */
-- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem;
 
 /**
- Returns an initialized weight answer format using the specified default/minimum/maximum values, 
- additional precision, and measurement system.
+ Returns an initialized weight answer format using the specified measurement system and numeric
+ precision.
  
- @param defaultValue            The default value to display. When the value of this parameter is `nil`, the
- picker displays 60 kg (or 133 lbs).
- @param minimumValue            The minimum value that is accessible in the picker. If the value of this
- parameter is `nil`, 0 kg (or 0 lbs) is the minimum.
- @param maximumValue            The maximum value that is accessible in the picker. If the value of this
- parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
- @param valueInterval           The interval at which the picker should display kilograms. The default is .5 
- otherwise zero. If value interval is non-zero or if 'nil' the default is used.
- @param additionalPrecision     Pass `YES` to allow additional precision; for the default, pass `NO`.
  @param measurementSystem       The measurement system to use. See `ORKMeasurementSystem` for the
- accepted values.
+                                    accepted values.
+ @param numericPrecision        The numeric precision used by the picker. If you pass
+                                    `ORKNumericPrecisionDefault`, the picker will use 0.5 kg
+                                    increments for the metric measurement system and whole pound
+                                    increments for the USC measurement system, which mimics the
+                                    default iOS behavior. If you pass `ORKNumericPrecissionLow`, the
+                                    picker will use 1 kg increments for the metric measurement
+                                    system and whole pound increments for the USC measurement
+                                    system. If you pass `ORKNumericPrecissionHigher`, the picker
+                                    use 0.01 gr increments for the metric measurement system,
+                                    and ounce increments for the USC measurement system.
  
  @return An initialized weight answer format.
  */
-- (instancetype)initWithDefaultValue:(nullable NSNumber *)defaultValue
-                        minimumValue:(nullable NSNumber *)minimumValue
-                        maximumValue:(nullable NSNumber *)maximumValue
-                       valueInterval:(nullable NSNumber *)valueInterval
-                 additionalPrecision:(BOOL)additionalPrecision
-                   measurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                         numericPrecision:(ORKNumericPrecision)numericPrecision;
+
+/**
+ Returns an initialized weight answer format using the specified measurement system, numeric
+ precision, and default, minimum and maximum values.
+ 
+ @param measurementSystem       The measurement system to use. See `ORKMeasurementSystem` for the
+                                    accepted values.
+ @param numericPrecision        The numeric precision used by the picker. If you pass
+                                    `ORKNumericPrecisionDefault`, the picker will use 0.5 kg
+                                    increments for the metric measurement system and whole pound
+                                    increments for the USC measurement system, which mimics the
+                                    default iOS behavior. If you pass `ORKNumericPrecissionLow`, the
+                                    picker will use 1 kg increments for the metric measurement
+                                    system and whole pound increments for the USC measurement
+                                    system. If you pass `ORKNumericPrecissionHigher`, the picker
+                                    use 0.01 gr increments for the metric measurement system,
+                                    and ounce increments for the USC measurement system.
+ @param defaultValue            The default value to display. When the value of this parameter is
+                                    `nil`, the picker displays 60 kg (or 133 lbs).
+ @param maximumValue            The maximum value that is accessible in the picker. If the value of
+                                    this parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
+ @param minimumValue            The minimum value that is accessible in the picker. If the value of
+                                    this parameter is `nil`, 0 kg (or 0 lbs) is the minimum.
+ 
+ @return An initialized weight answer format.
+ */
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                         numericPrecision:(ORKNumericPrecision)numericPrecision
+                             defaultValue:(nullable NSNumber *)defaultValue
+                             maximumValue:(nullable NSNumber *)maximumValue
+                             minimumValue:(nullable NSNumber *)minimumValue NS_DESIGNATED_INITIALIZER;
 
 /**
  Indicates the measurement system used by the answer format.
  */
 @property (readonly) ORKMeasurementSystem measurementSystem;
+
+/**
+ The numeric precision used by the picker.
+ 
+ An `ORKNumericPrecisionDefault` value indicates that the picker will use 0.5 kg increments for the
+ metric measurement system and whole pound increments for the USC measurement system, which mimics
+ the default iOS behavior. An `ORKNumericPrecissionLow` value indicates that the picker will use
+ 1 kg increments for the metric measurement system and whole pound increments for the USC
+ measurement system. An `ORKNumericPrecissionHigher` value indicates that the picker will use
+ 0.01 gr increments for the metric measurement system and ounce increments for the USC measurement
+ system.
+ 
+ The default value of this property is `ORKNumericPrecisionDefault`.
+ */
+@property (readonly, getter=isAdditionalPrecision) ORKNumericPrecision numericPrecission;
 
 /**
  The value to use as the default in the specified measurement system.
@@ -1520,20 +1569,6 @@ ORK_CLASS_AVAILABLE
  When the value of this property is `nil`, 657 kg (or 1,450 lbs) is the maximum.
  */
 @property (copy, readonly, nullable) NSNumber *maximumValue;
-
-/**
- The interval at which the picker should display kilograms. (ignored for USC and additionalPrecision=YES)
- 
- The default is .5 otherwise zero. If value is non-zero or if 'nil' the default is used.
- */
-@property (copy, readonly, nullable) NSNumber *valueInterval;
-
-/**
- A Boolean value indicating whether the value picker will display additional precision. (read-only)
-
- By default, the value of this property is `NO`.
- */
-@property (readonly, getter=isAdditionalPrecision) BOOL additionalPrecision;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2885,13 +2885,13 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
             if (self.numericPrecission != ORKNumericPrecisionHigh) {
                 double pounds = ORKKilogramsToPounds(((NSNumber *)answer).doubleValue);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
-                answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
+                answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LB", nil)];
             } else {
                 double pounds, ounces;
                 ORKKilogramsToPoundsAndOunces(((NSNumber *)answer).doubleValue, &pounds, &ounces);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
                 NSString *ouncesString = [formatter stringFromNumber:@(ounces)];
-                answerString = [NSString stringWithFormat:@"%@ %@, %@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil), ouncesString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
+                answerString = [NSString stringWithFormat:@"%@ %@, %@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LB", nil), ouncesString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
             }
         }
     }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -430,14 +430,14 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                                                   numericPrecision:(ORKNumericPrecision)numericPrecision
-                                                      defaultValue:(nullable NSNumber *)defaultValue
+                                                      minimumValue:(nullable NSNumber *)minimumValue
                                                       maximumValue:(nullable NSNumber *)maximumValue
-                                                      minimumValue:(nullable NSNumber *)minimumValue {
+                                                    defaultValue:(nullable NSNumber *)defaultValue {
     return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem
                                                    numericPrecision:numericPrecision
-                                                       defaultValue:defaultValue
+                                                       minimumValue:minimumValue
                                                        maximumValue:maximumValue
-                                                       minimumValue:minimumValue];
+                                                       defaultValue:defaultValue];
 }
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat {
@@ -2780,40 +2780,40 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 - (instancetype)init {
     return [self initWithMeasurementSystem:ORKMeasurementSystemLocal
                           numericPrecision:ORKNumericPrecisionDefault
-                              defaultValue:nil
+                              minimumValue:nil
                               maximumValue:nil
-                              minimumValue:nil];
+                              defaultValue:nil];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
     return [self initWithMeasurementSystem:measurementSystem
                           numericPrecision:ORKNumericPrecisionDefault
-                              defaultValue:nil
+                              minimumValue:nil
                               maximumValue:nil
-                              minimumValue:nil];
+                              defaultValue:nil];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision {
     return [self initWithMeasurementSystem:measurementSystem
                           numericPrecision:numericPrecision
-                              defaultValue:nil
+                              minimumValue:nil
                               maximumValue:nil
-                              minimumValue:nil];
+                              defaultValue:nil];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision
-                             defaultValue:(nullable NSNumber *)defaultValue
+                             minimumValue:(nullable NSNumber *)minimumValue
                              maximumValue:(nullable NSNumber *)maximumValue
-                             minimumValue:(nullable NSNumber *)minimumValue {
+                             defaultValue:(nullable NSNumber *)defaultValue {
     self = [super init];
     if (self) {
         _measurementSystem = measurementSystem;
         _numericPrecission = numericPrecision;
-        _defaultValue = defaultValue;
-        _maximumValue = maximumValue;
         _minimumValue = minimumValue;
+        _maximumValue = maximumValue;
+        _defaultValue = defaultValue;
     }
     return self;
 }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -430,9 +430,9 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                                                   numericPrecision:(ORKNumericPrecision)numericPrecision
-                                                      minimumValue:(nullable NSNumber *)minimumValue
-                                                      maximumValue:(nullable NSNumber *)maximumValue
-                                                    defaultValue:(nullable NSNumber *)defaultValue {
+                                                      minimumValue:(double)minimumValue
+                                                      maximumValue:(double)maximumValue
+                                                    defaultValue:(double)defaultValue {
     return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem
                                                    numericPrecision:numericPrecision
                                                        minimumValue:minimumValue
@@ -2780,33 +2780,39 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 - (instancetype)init {
     return [self initWithMeasurementSystem:ORKMeasurementSystemLocal
                           numericPrecision:ORKNumericPrecisionDefault
-                              minimumValue:nil
-                              maximumValue:nil
-                              defaultValue:nil];
+                              minimumValue:ORKDoubleDefaultValue
+                              maximumValue:ORKDoubleDefaultValue
+                              defaultValue:ORKDoubleDefaultValue];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
     return [self initWithMeasurementSystem:measurementSystem
                           numericPrecision:ORKNumericPrecisionDefault
-                              minimumValue:nil
-                              maximumValue:nil
-                              defaultValue:nil];
+                              minimumValue:ORKDoubleDefaultValue
+                              maximumValue:ORKDoubleDefaultValue
+                              defaultValue:ORKDoubleDefaultValue];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision {
     return [self initWithMeasurementSystem:measurementSystem
                           numericPrecision:numericPrecision
-                              minimumValue:nil
-                              maximumValue:nil
-                              defaultValue:nil];
+                              minimumValue:ORKDoubleDefaultValue
+                              maximumValue:ORKDoubleDefaultValue
+                              defaultValue:ORKDoubleDefaultValue];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision
-                             minimumValue:(nullable NSNumber *)minimumValue
-                             maximumValue:(nullable NSNumber *)maximumValue
-                             defaultValue:(nullable NSNumber *)defaultValue {
+                             minimumValue:(double)minimumValue
+                             maximumValue:(double)maximumValue
+                             defaultValue:(double)defaultValue {
+    if ((defaultValue != ORKDoubleDefaultValue) && ((defaultValue < minimumValue) || (defaultValue > maximumValue))) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                       reason:@"defaultValue must be between minimumValue and maximumValue."
+                                     userInfo:nil];
+    }
+
     self = [super init];
     if (self) {
         _measurementSystem = measurementSystem;

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -407,7 +407,7 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 }
 
 + (ORKHeightAnswerFormat *)heightAnswerFormat {
-    return [[ORKHeightAnswerFormat alloc] init];
+    return [ORKHeightAnswerFormat new];
 }
 
 + (ORKHeightAnswerFormat *)heightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
@@ -415,25 +415,29 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 }
 
 + (ORKWeightAnswerFormat *)weightAnswerFormat {
-    return [[ORKWeightAnswerFormat alloc] init];
+    return [ORKWeightAnswerFormat new];
 }
 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
     return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem];
 }
 
-+ (ORKWeightAnswerFormat *)weightAnswerFormatWithDefaultValue:(nullable NSNumber *)defaultValue
-                                                 minimumValue:(nullable NSNumber *)minimumValue
-                                                 maximumValue:(nullable NSNumber *)maximumValue
-                                                valueInterval:(nullable NSNumber *)valueInterval
-                                          additionalPrecision:(BOOL)additionalPrecision
-                                            measurementSystem:(ORKMeasurementSystem)measurementSystem {
-    return [[ORKWeightAnswerFormat alloc] initWithDefaultValue:defaultValue
-                                                  minimumValue:minimumValue
-                                                  maximumValue:maximumValue
-                                                 valueInterval:valueInterval
-                                           additionalPrecision:additionalPrecision
-                                             measurementSystem:measurementSystem];
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                                                  numericPrecision:(ORKNumericPrecision)numericPrecision {
+    return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem
+                                                   numericPrecision:numericPrecision];
+}
+
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                                                  numericPrecision:(ORKNumericPrecision)numericPrecision
+                                                      defaultValue:(nullable NSNumber *)defaultValue
+                                                      maximumValue:(nullable NSNumber *)maximumValue
+                                                      minimumValue:(nullable NSNumber *)minimumValue {
+    return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem
+                                                   numericPrecision:numericPrecision
+                                                       defaultValue:defaultValue
+                                                       maximumValue:maximumValue
+                                                       minimumValue:minimumValue];
 }
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat {
@@ -2774,33 +2778,42 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 }
 
 - (instancetype)init {
-    self = [self initWithMeasurementSystem:ORKMeasurementSystemLocal];
-    return self;
+    return [self initWithMeasurementSystem:ORKMeasurementSystemLocal
+                          numericPrecision:ORKNumericPrecisionDefault
+                              defaultValue:nil
+                              maximumValue:nil
+                              minimumValue:nil];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
-    self = [super init];
-    if (self) {
-        _additionalPrecision = NO;
-        _measurementSystem = measurementSystem;
-    }
-    return self;
+    return [self initWithMeasurementSystem:measurementSystem
+                          numericPrecision:ORKNumericPrecisionDefault
+                              defaultValue:nil
+                              maximumValue:nil
+                              minimumValue:nil];
 }
 
-- (instancetype)initWithDefaultValue:(nullable NSNumber *)defaultValue
-                        minimumValue:(nullable NSNumber *)minimumValue
-                        maximumValue:(nullable NSNumber *)maximumValue
-                       valueInterval:(nullable NSNumber *)valueInterval
-                 additionalPrecision:(BOOL)additionalPrecision
-                   measurementSystem:(ORKMeasurementSystem)measurementSystem {
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                         numericPrecision:(ORKNumericPrecision)numericPrecision {
+    return [self initWithMeasurementSystem:measurementSystem
+                          numericPrecision:numericPrecision
+                              defaultValue:nil
+                              maximumValue:nil
+                              minimumValue:nil];
+}
+
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                         numericPrecision:(ORKNumericPrecision)numericPrecision
+                             defaultValue:(nullable NSNumber *)defaultValue
+                             maximumValue:(nullable NSNumber *)maximumValue
+                             minimumValue:(nullable NSNumber *)minimumValue {
     self = [super init];
     if (self) {
-        _defaultValue = defaultValue;
-        _minimumValue = minimumValue;
-        _maximumValue = maximumValue;
-        _valueInterval = valueInterval;
-        _additionalPrecision = additionalPrecision;
         _measurementSystem = measurementSystem;
+        _numericPrecission = numericPrecision;
+        _defaultValue = defaultValue;
+        _maximumValue = maximumValue;
+        _minimumValue = minimumValue;
     }
     return self;
 }
@@ -2851,7 +2864,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
             answerString = [NSString stringWithFormat:@"%@ %@", [formatter stringFromNumber:answer], ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
         } else {
             double pounds, ounces;
-            if (!self.additionalPrecision) {
+            if (self.numericPrecission != ORKNumericPrecisionHigh) {
                 ORKKilogramsToPounds(((NSNumber *)answer).doubleValue, &pounds);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
                 answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2829,17 +2829,26 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            (self.measurementSystem == castObject.measurementSystem));
+            (self.measurementSystem == castObject.measurementSystem) &&
+            (self.numericPrecission == castObject.numericPrecission) &&
+            (self.minimumValue == castObject.minimumValue) &&
+            (self.maximumValue == castObject.maximumValue) &&
+            (self.defaultValue == castObject.defaultValue));
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ _measurementSystem;
+    // Ignore minimumValue, maximumValue and defaultValue as they're unimportant
+    return super.hash ^ _measurementSystem ^ _numericPrecission;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_ENUM(aDecoder, measurementSystem);
+        ORK_DECODE_ENUM(aDecoder, numericPrecission);
+        ORK_DECODE_DOUBLE(aDecoder, minimumValue);
+        ORK_DECODE_DOUBLE(aDecoder, maximumValue);
+        ORK_DECODE_DOUBLE(aDecoder, defaultValue);
     }
     return self;
 }
@@ -2847,6 +2856,10 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_ENUM(aCoder, measurementSystem);
+    ORK_ENCODE_ENUM(aCoder, numericPrecission);
+    ORK_ENCODE_DOUBLE(aCoder, minimumValue);
+    ORK_ENCODE_DOUBLE(aCoder, maximumValue);
+    ORK_ENCODE_DOUBLE(aCoder, defaultValue);
 }
 
 - (ORKQuestionType)questionType {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2869,12 +2869,12 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
         if (self.useMetricSystem) {
             answerString = [NSString stringWithFormat:@"%@ %@", [formatter stringFromNumber:answer], ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
         } else {
-            double pounds, ounces;
             if (self.numericPrecission != ORKNumericPrecisionHigh) {
-                ORKKilogramsToPounds(((NSNumber *)answer).doubleValue, &pounds);
+                double pounds = ORKKilogramsToPounds(((NSNumber *)answer).doubleValue);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
                 answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
             } else {
+                double pounds, ounces;
                 ORKKilogramsToPoundsAndOunces(((NSNumber *)answer).doubleValue, &pounds, &ounces);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
                 NSString *ouncesString = [formatter stringFromNumber:@(ounces)];

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2848,18 +2848,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
     if (!ORKIsAnswerEmpty(answer)) {
         NSNumberFormatter *formatter = ORKDecimalNumberFormatter();
         if (self.useMetricSystem) {
-            double whole, fraction;
-            ORKKilogramsToWholeAndFractions(((NSNumber *)answer).doubleValue, &whole, &fraction);
-            NSString *wholeString = [formatter stringFromNumber:@(whole)];
-            NSString *fractionString = [formatter stringFromNumber:@(fraction)];
-            if (!self.additionalPrecision && fraction == 0.0) {
-                answerString = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-            } else if (!self.additionalPrecision && fraction == 50.0) {
-                wholeString = [formatter stringFromNumber:@(whole + 0.5)];
-                answerString = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-            } else {
-                answerString = [NSString stringWithFormat:@"%@.%@ %@", wholeString, fractionString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-            }
+            answerString = [NSString stringWithFormat:@"%@ %@", [formatter stringFromNumber:answer], ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
         } else {
             double pounds, ounces;
             if (!self.additionalPrecision) {

--- a/ResearchKit/Common/ORKHeightPicker.m
+++ b/ResearchKit/Common/ORKHeightPicker.m
@@ -134,24 +134,7 @@
 }
 
 - (NSString *)selectedLabelText {
-    if (_answer == nil || _answer == ORKNullAnswerValue()) {
-        return nil;
-    }
-
-    NSNumberFormatter *formatter = ORKDecimalNumberFormatter();
-    NSString *selectedLabelText = nil;
-    if (_answerFormat.useMetricSystem) {
-        selectedLabelText = [NSString stringWithFormat:@"%@ %@", [formatter stringFromNumber:_answer], ORKLocalizedString(@"MEASURING_UNIT_CM", nil)];
-    } else {
-        double feet, inches;
-        ORKCentimetersToFeetAndInches(((NSNumber *)_answer).doubleValue, &feet, &inches);
-        NSString *feetString = [formatter stringFromNumber:@(feet)];
-        NSString *inchesString = [formatter stringFromNumber:@(inches)];
-
-        selectedLabelText = [NSString stringWithFormat:@"%@ %@, %@ %@",
-         feetString, ORKLocalizedString(@"MEASURING_UNIT_FT", nil), inchesString, ORKLocalizedString(@"MEASURING_UNIT_IN", nil)];
-    }
-    return selectedLabelText;
+    return [_answerFormat stringForAnswer:_answer];
 }
 
 - (void)pickerWillAppear {

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -308,42 +308,43 @@ ORK_INLINE void ORKKilogramsToWholeAndFractions(double kilograms, double *outWho
     *outFraction = round((kilograms - floor(kilograms)) * 100);
 }
 
-ORK_INLINE void ORKKilogramsToPounds(double kilograms, double *outPounds) {
-    if (outPounds == NULL) {
-        return;
+ORK_INLINE void ORKKilogramsToPoundsAndOunces(double kilograms, double * _Nullable outPounds, double * _Nullable outOunces) {
+    const double ORKPoundsPerKilogram = 2.20462262;
+    double fractionalPounds = kilograms * ORKPoundsPerKilogram;
+    double pounds = floor(fractionalPounds);
+    double ounces = round((fractionalPounds - pounds) * 16);
+    if (ounces == 16) {
+        pounds += 1;
+        ounces = 0;
     }
-    double lbs = kilograms * 2.2046;
-    *outPounds = round(lbs);
+    if (outPounds != NULL) {
+        *outPounds = pounds;
+    }
+    if (outOunces != NULL) {
+        *outOunces = ounces;
+    }
 }
 
-ORK_INLINE void ORKKilogramsToPoundsAndOunces(double kilograms, double *outPounds, double *outOunces) {
-    if (outPounds == NULL || outOunces == NULL) {
-        return;
-    }
-    double lbs = kilograms * 2.2046;
-    *outPounds = floor(lbs);
-    double oz = (lbs - floor(lbs)) * 16;
-    *outOunces = round(oz);
-    
-    if (round(oz) == 16) {
-        *outPounds += 1;
-        *outOunces = 0;
-    }
+ORK_INLINE double ORKKilogramsToPounds(double kilograms) {
+    double pounds;
+    ORKKilogramsToPoundsAndOunces(kilograms, &pounds, NULL);
+    return pounds;
 }
 
 ORK_INLINE double ORKWholeAndFractionsToKilograms(double whole, double fraction) {
     double kg = (whole + (fraction / 100));
-    return (round(100*kg)/100);
+    return (round(100 * kg) / 100);
 }
 
 ORK_INLINE double ORKPoundsToKilograms(double pounds) {
-    double kg = pounds * 0.4536;
-    return (round(100*kg)/100);
+    const double ORKKilogramsPerPound = 0.45359237;
+    double kg = pounds * ORKKilogramsPerPound;
+    return (round(100 * kg) / 100);
 }
 
 ORK_INLINE double ORKPoundsAndOuncesToKilograms(double pounds, double ounces) {
     double kg = (pounds + (ounces / 16)) * 0.4536;
-    return (round(100*kg)/100);
+    return (round(100 * kg) / 100);
 }
 
 ORK_INLINE UIColor *ORKOpaqueColorWithReducedAlphaFromBaseColor(UIColor *baseColor, NSUInteger colorIndex, NSUInteger totalColors) {

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -336,15 +336,14 @@ ORK_INLINE double ORKWholeAndFractionToKilograms(double whole, double fraction) 
     return (round(100 * kg) / 100);
 }
 
-ORK_INLINE double ORKPoundsToKilograms(double pounds) {
+ORK_INLINE double ORKPoundsAndOuncesToKilograms(double pounds, double ounces) {
     const double ORKKilogramsPerPound = 0.45359237;
-    double kg = pounds * ORKKilogramsPerPound;
+    double kg = (pounds + (ounces / 16)) * ORKKilogramsPerPound;
     return (round(100 * kg) / 100);
 }
 
-ORK_INLINE double ORKPoundsAndOuncesToKilograms(double pounds, double ounces) {
-    double kg = (pounds + (ounces / 16)) * 0.4536;
-    return (round(100 * kg) / 100);
+ORK_INLINE double ORKPoundsToKilograms(double pounds) {
+    return ORKPoundsAndOuncesToKilograms(pounds, 0);
 }
 
 ORK_INLINE UIColor *ORKOpaqueColorWithReducedAlphaFromBaseColor(UIColor *baseColor, NSUInteger colorIndex, NSUInteger totalColors) {

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -300,7 +300,7 @@ ORK_INLINE double ORKFeetAndInchesToCentimeters(double feet, double inches) {
     return ORKInchesToCentimeters(ORKFeetAndInchesToInches(feet, inches));
 }
 
-ORK_INLINE void ORKKilogramsToWholeAndFractions(double kilograms, double *outWhole, double *outFraction) {
+ORK_INLINE void ORKKilogramsToWholeAndFraction(double kilograms, double *outWhole, double *outFraction) {
     if (outWhole == NULL || outFraction == NULL) {
         return;
     }
@@ -331,7 +331,7 @@ ORK_INLINE double ORKKilogramsToPounds(double kilograms) {
     return pounds;
 }
 
-ORK_INLINE double ORKWholeAndFractionsToKilograms(double whole, double fraction) {
+ORK_INLINE double ORKWholeAndFractionToKilograms(double whole, double fraction) {
     double kg = (whole + (fraction / 100));
     return (round(100 * kg) / 100);
 }

--- a/ResearchKit/Common/ORKTypes.h
+++ b/ResearchKit/Common/ORKTypes.h
@@ -298,4 +298,7 @@ typedef NS_ENUM(NSInteger, ORKNumericPrecision) {
 } ORK_ENUM_AVAILABLE;
 
 
+extern const double ORKDoubleDefaultValue ORK_AVAILABLE_DECL;
+
+
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKTypes.h
+++ b/ResearchKit/Common/ORKTypes.h
@@ -265,9 +265,9 @@ typedef NS_ENUM(NSInteger, ORKProgressIndicatorType) {
 
 
 /**
- System of measurements.
+ Measurement system.
  
- Used mainly by ORKHeightAnswerFormat and ORKWeightAnswerFormat.
+ Used by ORKHeightAnswerFormat and ORKWeightAnswerFormat.
  */
 typedef NS_ENUM(NSInteger, ORKMeasurementSystem) {
     /// Measurement system in use by the current locale.
@@ -279,5 +279,23 @@ typedef NS_ENUM(NSInteger, ORKMeasurementSystem) {
     /// United States customary system.
     ORKMeasurementSystemUSC,
 } ORK_ENUM_AVAILABLE;
+
+
+/**
+ Numeric precision.
+ 
+ Used by ORKWeightAnswerFormat.
+ */
+typedef NS_ENUM(NSInteger, ORKNumericPrecision) {
+    /// Default numeric precision.
+    ORKNumericPrecisionDefault = 0,
+    
+    /// Low numeric precision.
+    ORKNumericPrecisionLow,
+    
+    /// High numeric preicision.
+    ORKNumericPrecisionHigh,
+} ORK_ENUM_AVAILABLE;
+
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKTypes.m
+++ b/ResearchKit/Common/ORKTypes.m
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2017, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import "ORKTypes.h"
+
+
+const double ORKDoubleDefaultValue = DBL_MAX;

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -269,7 +269,7 @@
         }
     } else {
         if (component == 0) {
-            title = [NSString stringWithFormat:@"%@ %@", _majorValues[row], ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
+            title = [NSString stringWithFormat:@"%@ %@", _majorValues[row], ORKLocalizedString(@"MEASURING_UNIT_LB", nil)];
         } else {
             title = [NSString stringWithFormat:@"%@ %@", _minorValues[row], ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
         }

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -123,8 +123,7 @@
         }
     } else {
         if (_answerFormat.numericPrecission != ORKNumericPrecisionHigh) {
-            double pounds;
-            ORKKilogramsToPounds(((NSNumber *)answer).doubleValue, &pounds);
+            double pounds = ORKKilogramsToPounds(((NSNumber *)answer).doubleValue);
             NSUInteger poundsIndex = [_majorValues indexOfObject:@((NSInteger)pounds)];
             if (poundsIndex == NSNotFound) {
                 [self setAnswer:[self defaultAnswerValue]];

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -196,42 +196,7 @@
 }
 
 - (NSString *)selectedLabelText {
-    if (_answer == nil || _answer == ORKNullAnswerValue()) {
-        return nil;
-    }
-    
-    NSNumberFormatter *formatter = ORKDecimalNumberFormatter();
-    NSString *selectedLabelText = nil;
-    if (_answerFormat.useMetricSystem) {
-        double whole, fraction;
-        ORKKilogramsToWholeAndFractions(((NSNumber *)_answer).doubleValue, &whole, &fraction);
-        NSString *wholeString = [formatter stringFromNumber:@(whole)];
-        if (!_answerFormat.additionalPrecision && fraction == 0.0) {
-            selectedLabelText = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-        } else if (!_answerFormat.additionalPrecision && fraction == 50.0) {
-            wholeString = [formatter stringFromNumber:@(whole + 0.5)];
-            selectedLabelText = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-        } else {
-            formatter.minimumIntegerDigits = 2;
-            formatter.maximumFractionDigits = 0;
-            NSString *fractionString = [formatter stringFromNumber:@(fraction)];
-            selectedLabelText = [NSString stringWithFormat:@"%@.%@ %@", wholeString, fractionString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-        }
-    } else {
-        double pounds, ounces;
-        if (!_answerFormat.additionalPrecision) {
-            ORKKilogramsToPounds(((NSNumber *)_answer).doubleValue, &pounds);
-            NSString *poundsString = [formatter stringFromNumber:@(pounds)];
-            selectedLabelText = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
-        } else {
-            ORKKilogramsToPoundsAndOunces(((NSNumber *)_answer).doubleValue, &pounds, &ounces);
-            NSString *poundsString = [formatter stringFromNumber:@(pounds)];
-            NSString *ouncesString = [formatter stringFromNumber:@(ounces)];
-            selectedLabelText = [NSString stringWithFormat:@"%@ %@, %@ %@",
-                                 poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil), ouncesString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
-        }
-    }
-    return selectedLabelText;
+    return [_answerFormat stringForAnswer:_answer];
 }
 
 - (void)pickerWillAppear {

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -110,7 +110,7 @@
             [_pickerView selectRow:index inComponent:0 animated:NO];
         } else {
             double whole, fraction;
-            ORKKilogramsToWholeAndFractions(((NSNumber *)answer).doubleValue, &whole, &fraction);
+            ORKKilogramsToWholeAndFraction(((NSNumber *)answer).doubleValue, &whole, &fraction);
             NSUInteger wholeIndex = [_majorValues indexOfObject:@((NSInteger)whole)];
             NSUInteger fractionIndex = [_minorValues indexOfObject:@((NSInteger)fraction)];
             if (wholeIndex == NSNotFound || fractionIndex == NSNotFound) {
@@ -184,7 +184,7 @@
         } else {
             NSInteger fractionRow = [_pickerView selectedRowInComponent:1];
             NSNumber *fraction = _minorValues[fractionRow];
-            answer = @( ORKWholeAndFractionsToKilograms(whole.doubleValue, fraction.doubleValue) );
+            answer = @( ORKWholeAndFractionToKilograms(whole.doubleValue, fraction.doubleValue) );
         }
     } else {
         NSInteger poundsRow = [_pickerView selectedRowInComponent:0];

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -181,7 +181,7 @@
 "MEASURING_UNIT_FT" = "ft";
 "MEASURING_UNIT_IN" = "in";
 "MEASURING_UNIT_KG" = "kg";
-"MEASURING_UNIT_LBS" = "lbs";
+"MEASURING_UNIT_LB" = "lb";
 "MEASURING_UNIT_OZ" = "oz";
 
 /* Limb values. */

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1921,7 +1921,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_003" text:@"Weight"
                                                            answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemUSC]];
-            item.placeholder = @"Pick a weight (imperial system)";
+            item.placeholder = @"Pick a weight (USC system)";
             [items addObject:item];
         }
 
@@ -1932,7 +1932,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                                                                                     minimumValue:10
                                                                                                                     maximumValue:20
                                                                                                                     defaultValue:11.5]];
-            item.placeholder = @"Pick a weight (metric system)";
+            item.placeholder = @"Pick a weight (metric system, low precision)";
             [items addObject:item];
         }
 
@@ -1943,7 +1943,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                                                                                     minimumValue:10
                                                                                                                     maximumValue:20
                                                                                                                     defaultValue:11.5]];
-            item.placeholder = @"Pick a weight (metric system)";
+            item.placeholder = @"Pick a weight (USC system, low precision)";
             [items addObject:item];
         }
 
@@ -1954,7 +1954,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                                                                                     minimumValue:10
                                                                                                                     maximumValue:20
                                                                                                                     defaultValue:11.5]];
-            item.placeholder = @"Pick a weight (metric system)";
+            item.placeholder = @"Pick a weight (metric system, high precision)";
             [items addObject:item];
         }
         
@@ -1965,7 +1965,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                                                                                     minimumValue:10
                                                                                                                     maximumValue:20
                                                                                                                     defaultValue:11.5]];
-            item.placeholder = @"Pick a weight (metric system)";
+            item.placeholder = @"Pick a weight (USC system, high precision)";
             [items addObject:item];
         }
 

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1917,14 +1917,58 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
             item.placeholder = @"Pick a weight (metric system)";
             [items addObject:item];
         }
-        
+
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_003" text:@"Weight"
                                                            answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemUSC]];
             item.placeholder = @"Pick a weight (imperial system)";
             [items addObject:item];
         }
+
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_004" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemMetric
+                                                                                                                numericPrecision:ORKNumericPrecisionLow
+                                                                                                                    minimumValue:10
+                                                                                                                    maximumValue:20
+                                                                                                                    defaultValue:11.5]];
+            item.placeholder = @"Pick a weight (metric system)";
+            [items addObject:item];
+        }
+
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_005" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemUSC
+                                                                                                                numericPrecision:ORKNumericPrecisionLow
+                                                                                                                    minimumValue:10
+                                                                                                                    maximumValue:20
+                                                                                                                    defaultValue:11.5]];
+            item.placeholder = @"Pick a weight (metric system)";
+            [items addObject:item];
+        }
+
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_006" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemMetric
+                                                                                                                numericPrecision:ORKNumericPrecisionHigh
+                                                                                                                    minimumValue:10
+                                                                                                                    maximumValue:20
+                                                                                                                    defaultValue:11.5]];
+            item.placeholder = @"Pick a weight (metric system)";
+            [items addObject:item];
+        }
         
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_007" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemUSC
+                                                                                                                numericPrecision:ORKNumericPrecisionHigh
+                                                                                                                    minimumValue:10
+                                                                                                                    maximumValue:20
+                                                                                                                    defaultValue:11.5]];
+            item.placeholder = @"Pick a weight (metric system)";
+            [items addObject:item];
+        }
+
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_date_001" text:@"Birthdate"
                                                          answerFormat:[ORKAnswerFormat dateAnswerFormat]];

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -788,45 +788,45 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         let step1 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep1), title: "Weight", answer: answerFormat1)
         
-        step1.text = "local system"
+        step1.text = "local system, default precision"
         
         let answerFormat2 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric)
         
         let step2 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep2), title: "Weight", answer: answerFormat2)
         
-        step2.text = "metric system, default"
+        step2.text = "metric system, default precision"
         
-        let answerFormat3 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC)
+        let answerFormat3 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric, numericPrecision: ORKNumericPrecision.low, minimumValue: ORKDoubleDefaultValue, maximumValue: ORKDoubleDefaultValue, defaultValue: ORKDoubleDefaultValue)
         
         let step3 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep3), title: "Weight", answer: answerFormat3)
         
-        step3.text = "USC system"
-        
-        let answerFormat4 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 45.50, minimumValue: 20.0, maximumValue: 100.0, valueInterval: nil, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.metric)
+        step3.text = "metric system, low precision"
+
+        let answerFormat4 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric, numericPrecision: ORKNumericPrecision.high, minimumValue: 20.0, maximumValue: 100.0, defaultValue:  45.50)
         
         let step4 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep4), title: "Weight", answer: answerFormat4)
         
-        step4.text = "metric system, additional precision"
-        
-        let answerFormat5 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 100.0, minimumValue: 50.0, maximumValue: 150.0, valueInterval: nil, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.USC)
+        step4.text = "metric system, high precision"
+
+        let answerFormat5 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC)
         
         let step5 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep5), title: "Weight", answer: answerFormat5)
         
-        step5.text = "USC system, additional precision"
-
-        let answerFormat6 = ORKHealthKitQuantityTypeAnswerFormat(quantityType: HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMass)!, unit: HKUnit.gramUnit(with: .kilo), style: .decimal)
+        step5.text = "USC system, default precision"
+        
+        let answerFormat6 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC, numericPrecision: ORKNumericPrecision.high, minimumValue: 50.0, maximumValue: 150.0, defaultValue: 100.0)
         
         let step6 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep6), title: "Weight", answer: answerFormat6)
         
-        step6.text = "HealthKit, body mass"
-        
-        let answerFormat7 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: nil, minimumValue: nil, maximumValue: nil, valueInterval: 0.0, additionalPrecision: false, measurementSystem: ORKMeasurementSystem.metric)
+        step6.text = "USC system, high precision"
+
+        let answerFormat7 = ORKHealthKitQuantityTypeAnswerFormat(quantityType: HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMass)!, unit: HKUnit.gramUnit(with: .kilo), style: .decimal)
         
         let step7 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep7), title: "Weight", answer: answerFormat7)
         
-        step7.text = "metric system, no decimal places"
-                
-        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step7, step3, step4, step5, step6])
+        step7.text = "HealthKit, body mass"
+
+        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step3, step4, step5, step6, step7])
     }
     
     /**

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -759,13 +759,13 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         let step1 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep1), title: "Height", answer: answerFormat1)
         
-        step1.text = "local system"
+        step1.text = "Local system"
 
         let answerFormat2 = ORKAnswerFormat.heightAnswerFormat(with: ORKMeasurementSystem.metric)
         
         let step2 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep2), title: "Height", answer: answerFormat2)
         
-        step2.text = "metric system"
+        step2.text = "Metric system"
 
         let answerFormat3 = ORKAnswerFormat.heightAnswerFormat(with: ORKMeasurementSystem.USC)
         
@@ -788,25 +788,25 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         let step1 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep1), title: "Weight", answer: answerFormat1)
         
-        step1.text = "local system, default precision"
+        step1.text = "Local system, default precision"
         
         let answerFormat2 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric)
         
         let step2 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep2), title: "Weight", answer: answerFormat2)
         
-        step2.text = "metric system, default precision"
+        step2.text = "Metric system, default precision"
         
         let answerFormat3 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric, numericPrecision: ORKNumericPrecision.low, minimumValue: ORKDoubleDefaultValue, maximumValue: ORKDoubleDefaultValue, defaultValue: ORKDoubleDefaultValue)
         
         let step3 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep3), title: "Weight", answer: answerFormat3)
         
-        step3.text = "metric system, low precision"
+        step3.text = "Metric system, low precision"
 
         let answerFormat4 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric, numericPrecision: ORKNumericPrecision.high, minimumValue: 20.0, maximumValue: 100.0, defaultValue:  45.50)
         
         let step4 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep4), title: "Weight", answer: answerFormat4)
         
-        step4.text = "metric system, high precision"
+        step4.text = "Metric system, high precision"
 
         let answerFormat5 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC)
         


### PR DESCRIPTION
Here are my final improvements as discussed in https://github.com/ResearchKit/ResearchKit/pull/1010.

I have included some additional improvements that I came up with such as replace `NSNumbers` parameters by `double`, to avoid needless boxing and unboxing. I also reordered the `ORKWeighAnswerFormat` parameters to take into account their importance.

I have an additional branch here: https://github.com/rsanchezsaez/ResearchKit/tree/rss/weight_answer_format which resolves conflicts with the latest master (because they merged some code refactor commits, but we can merge that one after this PR to simplify code reviewing).

@ninoguba Let me know what you think.